### PR TITLE
Use mainCamera variable

### DIFF
--- a/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/ObjectCreation/DefaultMeshConfiguration.cs
+++ b/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/ObjectCreation/DefaultMeshConfiguration.cs
@@ -99,7 +99,7 @@ namespace BAPointCloudRenderer.ObjectCreation {
                     material.SetMatrix("_InverseProjMatrix", invP);
                     material.SetFloat("_FOV", Mathf.Deg2Rad * mainCamera.fieldOfView);
                 }
-                Rect screen = Camera.main.pixelRect;
+                Rect screen = mainCamera.pixelRect;
                 material.SetInt("_ScreenWidth", (int)screen.width);
                 material.SetInt("_ScreenHeight", (int)screen.height);
             }

--- a/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/ObjectCreation/GeoQuadMeshConfiguration.cs
+++ b/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/ObjectCreation/GeoQuadMeshConfiguration.cs
@@ -139,7 +139,7 @@ namespace BAPointCloudRenderer.ObjectCreation {
                     material.SetMatrix("_InverseProjMatrix", invP);
                     material.SetFloat("_FOV", Mathf.Deg2Rad * mainCamera.fieldOfView);
                 }
-                Rect screen = Camera.main.pixelRect;
+                Rect screen = mainCamera.pixelRect;
                 material.SetInt("_ScreenWidth", (int)screen.width);
                 material.SetInt("_ScreenHeight", (int)screen.height);
             }


### PR DESCRIPTION
Hey so I needed to change this when using a camera that isn't main camera. In my case I'm using a SteamVR camera and the code breaks if it thinks it is supposed to use Camera.main.

In my case I also made the mainCamera variable public so I could use SteamVR's component, but I'm not including this in this PR since I don't want to impose that on the chosen design spec.

Love the library! Super fun.