### PR TITLE
Replaced InsideFrustum function

### DIFF
--- a/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/Loading/Util.cs
+++ b/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/Loading/Util.cs
@@ -49,5 +49,31 @@ namespace BAPointCloudRenderer.Loading {
             }
             return true;
         }
+		
+		        /// <summary>
+        /// Checks whether:
+        /// (a) the camera is inside the node bounding box,
+        /// (b) the bounding box center is inside the camera frustum, and
+        /// (c) a vertex of the bounding box is inside the camera frustum
+        /// </summary>
+        public static bool CameraFrustumBoundingBoxIntersection(BoundingBox box, Vector3 cameraPos, Plane[] frustum)
+        {
+            Vector3 sphereCenter = box.GetBoundsObject().center;
+            float sphereRadius = (float) box.Radius();
+            Vector3 heading = sphereCenter - cameraPos;
+            float distance = heading.magnitude;
+
+            if (sphereRadius > distance) return true; // Camera is inside the bounding box of the node
+            if (InsideFrustum(sphereCenter, frustum)) return true; // BoundingBox center lies within the frustum
+            if (InsideFrustum(new Vector3((float) box.Lx, (float) box.Ly, (float) box.Lz), frustum)) return true; // BoundingBox vertex lies withing the frustum
+            if (InsideFrustum(new Vector3((float) box.Lx, (float) box.Ly, (float) box.Uz), frustum)) return true; // BoundingBox vertex lies withing the frustum
+            if (InsideFrustum(new Vector3((float) box.Lx, (float) box.Uy, (float) box.Lz), frustum)) return true; // BoundingBox vertex lies withing the frustum
+            if (InsideFrustum(new Vector3((float) box.Lx, (float) box.Uy, (float) box.Uz), frustum)) return true; // BoundingBox vertex lies withing the frustum
+            if (InsideFrustum(new Vector3((float) box.Ux, (float) box.Ly, (float) box.Lz), frustum)) return true; // BoundingBox vertex lies withing the frustum
+            if (InsideFrustum(new Vector3((float) box.Ux, (float) box.Ly, (float) box.Uz), frustum)) return true; // BoundingBox vertex lies withing the frustum
+            if (InsideFrustum(new Vector3((float) box.Ux, (float) box.Uy, (float) box.Lz), frustum)) return true; // BoundingBox vertex lies withing the frustum
+            if (InsideFrustum(new Vector3((float) box.Ux, (float) box.Uy, (float) box.Uz), frustum)) return true; // BoundingBox vertex lies withing the frustum
+            return false;
+        }
     }
 }

--- a/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/Loading/V2TraversalThread.cs
+++ b/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/Loading/V2TraversalThread.cs
@@ -143,7 +143,7 @@ namespace BAPointCloudRenderer.Loading {
                 Node n = toProcess.Dequeue(); //Min Node Size was already checked
 
                 //Is Node inside frustum?
-                if (Util.InsideFrustum(n.BoundingBox, frustum)) {
+                if (Util.CameraFrustumBoundingBoxIntersection(n.BoundingBox, cameraPosition, frustum)) {
 
                     bool loadchildren = false;
                     lock (n) {


### PR DESCRIPTION
Following the discussion below this [issue](https://github.com/SFraissTU/BA_PointCloud/issues/13), I have replaced a utility function that is used to determine whether the bounding box of a node is in the camera frustum.