### PR TITLE
add compatibility with Potree 1.7 format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ PointCloudRenderer/.vs/
 
 
 # Unity3D generated meta files
-*.pidb.meta
+*.meta
 
 # Unity3D Generated File On Crash Reports
 */sysinfo.txt

--- a/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/CloudData/PointCloudMetaData.cs
+++ b/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/CloudData/PointCloudMetaData.cs
@@ -4,12 +4,10 @@ using UnityEngine;
 
 namespace BAPointCloudRenderer.CloudData
 {
-    /// <summary>
-    /// Description of Point Attribute. Created from the cloud.js-File.
-    /// </summary>
-    [Serializable]
-    public class PointAttribute
-    {
+
+  [Serializable]
+  public class PointAttribute
+  {
       public string name;
       public int size;
       public int elements;
@@ -17,7 +15,7 @@ namespace BAPointCloudRenderer.CloudData
       public string type;
       public string description;
 
-    }
+  }
     /// <summary>
     /// Description of a Bounding Box. Created from the cloud.js-File.
     /// Contains all attributes from that file plus two more: cloudPath (folder path of the cloud) and cloudName (name of the cloud)
@@ -52,10 +50,21 @@ namespace BAPointCloudRenderer.CloudData
         {
             Debug.Log("ReadFromJson");
             PointCloudMetaData data = JsonUtility.FromJson<PointCloudMetaData>(json);
-            data.pointByteSize = 0;
-            foreach (PointAttribute pointAttribute in data.pointAttributes) {
-              data.pointByteSize += pointAttribute.size;
+            if(data.version == "1.8"){
+              foreach (PointAttribute pointAttribute in data.pointAttributes) {
+                Debug.Log(pointAttribute.name);
+                Debug.Log(pointAttribute.size);
+                data.pointByteSize += pointAttribute.size;
+                }
+            }else{
+                //workarround for version < 1.7
+                data.pointByteSize = 16;
+                data.pointAttributes[0].name="POSITION_CARTESIAN";
+                data.pointAttributes[1].name="COLOR_PACKED";
             }
+            
+            Debug.Log(data.pointByteSize);
+
             data.boundingBox.Init();
             data.boundingBox.SwitchYZ();
             data.tightBoundingBox.SwitchYZ();

--- a/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/CloudData/PointCloudMetaData.cs
+++ b/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/CloudData/PointCloudMetaData.cs
@@ -5,6 +5,20 @@ using UnityEngine;
 namespace BAPointCloudRenderer.CloudData
 {
     /// <summary>
+    /// Description of Point Attribute. Created from the cloud.js-File.
+    /// </summary>
+    [Serializable]
+    public class PointAttribute
+    {
+      public string name;
+      public int size;
+      public int elements;
+      public int elementSize;
+      public string type;
+      public string description;
+
+    }
+    /// <summary>
     /// Description of a Bounding Box. Created from the cloud.js-File.
     /// Contains all attributes from that file plus two more: cloudPath (folder path of the cloud) and cloudName (name of the cloud)
     /// </summary>
@@ -17,7 +31,7 @@ namespace BAPointCloudRenderer.CloudData
         public int points;
         public BoundingBox boundingBox;
         public BoundingBox tightBoundingBox;
-        public List<string> pointAttributes;
+        public List<PointAttribute> pointAttributes;
         public double spacing;
         public double scale;
         public int hierarchyStepSize;
@@ -25,7 +39,10 @@ namespace BAPointCloudRenderer.CloudData
         public string cloudPath;
         [NonSerialized]
         public string cloudName;
-
+        [NonSerialized]
+        public string cloudUrl;
+        [NonSerialized]
+        public int pointByteSize;
         /// <summary>
         /// Reads the metadata from a json-string.
         /// </summary>
@@ -33,7 +50,12 @@ namespace BAPointCloudRenderer.CloudData
         /// <param name="moveToOrigin">True, iff the center of the bounding boxes should be moved to the origin</param>
         public static PointCloudMetaData ReadFromJson(string json, bool moveToOrigin)
         {
+            Debug.Log("ReadFromJson");
             PointCloudMetaData data = JsonUtility.FromJson<PointCloudMetaData>(json);
+            data.pointByteSize = 0;
+            foreach (PointAttribute pointAttribute in data.pointAttributes) {
+              data.pointByteSize += pointAttribute.size;
+            }
             data.boundingBox.Init();
             data.boundingBox.SwitchYZ();
             data.tightBoundingBox.SwitchYZ();

--- a/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/Loading/CloudLoader.cs
+++ b/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/Loading/CloudLoader.cs
@@ -1,4 +1,4 @@
-using BAPointCloudRenderer.CloudData;
+﻿using BAPointCloudRenderer.CloudData;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -20,6 +20,7 @@ namespace BAPointCloudRenderer.Loading {
          /// <param name="moveToOrigin">True, if the center of the cloud should be moved to the origin</param>
         public static PointCloudMetaData LoadMetaData(string cloudPath, bool moveToOrigin = false) {
             string jsonfile;
+            Debug.Log(cloudPath);
             bool isCloudOnline = Uri.IsWellFormedUriString(cloudPath, UriKind.Absolute);
             if (isCloudOnline){
                 WebClient client = new WebClient();
@@ -34,15 +35,19 @@ namespace BAPointCloudRenderer.Loading {
             }
 
             PointCloudMetaData metaData = PointCloudMetaData.ReadFromJson(jsonfile, moveToOrigin);
+            
+            metaData.cloudName =  cloudPath.Substring(0, cloudPath.Length-1).Substring(cloudPath.Substring(0, cloudPath.Length - 1).LastIndexOf("/") + 1);
+            Debug.Log(metaData.cloudName);
+            
             if (isCloudOnline){
               metaData.cloudUrl = cloudPath;
-              metaData.cloudPath = "temp";
+              metaData.cloudPath = "temp/"+metaData.cloudName+"/";
             }else{
               metaData.cloudPath = cloudPath;
               metaData.cloudUrl = null;
             }
 
-            metaData.cloudName =  cloudPath.Substring(0, cloudPath.Length-1).Substring(cloudPath.Substring(0, cloudPath.Length - 1).LastIndexOf("/") + 1);
+
             return metaData;
         }
 
@@ -198,9 +203,13 @@ namespace BAPointCloudRenderer.Loading {
                 path += id.Substring(i * metaData.hierarchyStepSize, metaData.hierarchyStepSize) + "/";
             }
             path += "r" + id + fileending;
+            //Debug.Log("FindAndLoadFile "+path);
             if (File.Exists(metaData.cloudPath + dataRPath + path)){
                 return File.ReadAllBytes(metaData.cloudPath + dataRPath + path);
             }else if(metaData.cloudUrl != null){
+              //Debug.Log(metaData.cloudUrl + dataRPath + path);
+              //Debug.Log(metaData.cloudPath + dataRPath + path);
+              Directory.CreateDirectory(Path.GetDirectoryName(metaData.cloudPath + dataRPath + path));
               WebClient webClient = new WebClient();
               webClient.DownloadFile(metaData.cloudUrl + dataRPath + path, metaData.cloudPath + dataRPath + path);
               return File.ReadAllBytes(metaData.cloudPath + dataRPath + path);
@@ -227,3 +236,4 @@ namespace BAPointCloudRenderer.Loading {
         }
     }
 }
+

--- a/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/Loading/CloudLoader.cs
+++ b/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/Loading/CloudLoader.cs
@@ -1,7 +1,9 @@
-﻿using BAPointCloudRenderer.CloudData;
+using BAPointCloudRenderer.CloudData;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Net;
+using System;
 using UnityEngine;
 
 namespace BAPointCloudRenderer.Loading {
@@ -18,23 +20,39 @@ namespace BAPointCloudRenderer.Loading {
          /// <param name="moveToOrigin">True, if the center of the cloud should be moved to the origin</param>
         public static PointCloudMetaData LoadMetaData(string cloudPath, bool moveToOrigin = false) {
             string jsonfile;
-            using (StreamReader reader = new StreamReader(cloudPath + "cloud.js", Encoding.Default)) {
+            bool isCloudOnline = Uri.IsWellFormedUriString(cloudPath, UriKind.Absolute);
+            if (isCloudOnline){
+                WebClient client = new WebClient();
+                Stream stream = client.OpenRead(cloudPath + "cloud.js");
+                StreamReader reader = new StreamReader(stream);
                 jsonfile = reader.ReadToEnd();
-                reader.Close();
+            }else{
+              using (StreamReader reader = new StreamReader(cloudPath + "cloud.js", Encoding.Default)) {
+                  jsonfile = reader.ReadToEnd();
+                  reader.Close();
+              }
             }
+
             PointCloudMetaData metaData = PointCloudMetaData.ReadFromJson(jsonfile, moveToOrigin);
-            metaData.cloudPath = cloudPath;
+            if (isCloudOnline){
+              metaData.cloudUrl = cloudPath;
+              metaData.cloudPath = "temp";
+            }else{
+              metaData.cloudPath = cloudPath;
+              metaData.cloudUrl = null;
+            }
+
             metaData.cloudName =  cloudPath.Substring(0, cloudPath.Length-1).Substring(cloudPath.Substring(0, cloudPath.Length - 1).LastIndexOf("/") + 1);
             return metaData;
         }
-        
+
         /// <summary>
         /// Loads the complete Hierarchy and ALL points from the pointcloud.
         /// </summary>
         /// <param name="metaData">MetaData-Object, as received by LoadMetaData</param>
         /// <returns>The Root Node of the point cloud</returns>
         public static Node LoadPointCloud(PointCloudMetaData metaData) {
-            string dataRPath = metaData.cloudPath + metaData.octreeDir + "/r/";
+            string dataRPath = metaData.octreeDir + "/r/"; //metaData.cloudPath + ...
             Node rootNode = new Node("", metaData, metaData.boundingBox, null);
             LoadHierarchy(dataRPath, metaData, rootNode);
             LoadAllPoints(dataRPath, metaData, rootNode);
@@ -47,7 +65,7 @@ namespace BAPointCloudRenderer.Loading {
         /// <param name="metaData">MetaData-Object, as received by LoadMetaData</param>
         /// <returns>The Root Node of the point cloud</returns>
         public static Node LoadHierarchyOnly(PointCloudMetaData metaData) {
-            string dataRPath = metaData.cloudPath + metaData.octreeDir + "/r/";
+            string dataRPath = metaData.octreeDir + "/r/"; //metaData.cloudPath + ...
             Node rootNode = new Node("", metaData, metaData.boundingBox, null);
             LoadHierarchy(dataRPath, metaData, rootNode);
             return rootNode;
@@ -57,7 +75,7 @@ namespace BAPointCloudRenderer.Loading {
         /// Loads the points for the given node
         /// </summary>
         public static void LoadPointsForNode(Node node) {
-            string dataRPath = node.MetaData.cloudPath + node.MetaData.octreeDir + "/r/";
+            string dataRPath = node.MetaData.octreeDir + "/r/"; //node.MetaData.cloudPath + ...
             LoadPoints(dataRPath, node.MetaData, node);
         }
 
@@ -128,15 +146,15 @@ namespace BAPointCloudRenderer.Loading {
         private static void LoadPoints(string dataRPath, PointCloudMetaData metaData, Node node) {
 
             byte[] data = FindAndLoadFile(dataRPath, metaData, node.Name, ".bin");
-            int pointByteSize = 16;//TODO: Is this always the case?
+            int pointByteSize = metaData.pointByteSize;//TODO: Is this always the case?
             int numPoints = data.Length / pointByteSize;
             int offset = 0;
 
             Vector3[] vertices = new Vector3[numPoints];
             Color[] colors = new Color[numPoints];
             //Read in data
-            foreach (string pointAttribute in metaData.pointAttributes) {
-                if (pointAttribute.Equals(PointAttributes.POSITION_CARTESIAN)) {
+            foreach (PointAttribute pointAttribute in metaData.pointAttributes) {
+                if (pointAttribute.name.Equals(PointAttributes.POSITION_CARTESIAN)) {
                     for (int i = 0; i < numPoints; i++) {
                         //Reduction to single precision!
                         //Note: y and z are switched
@@ -146,7 +164,7 @@ namespace BAPointCloudRenderer.Loading {
                         vertices[i] = new Vector3(x, y, z);
                     }
                     offset += 12;
-                } else if (pointAttribute.Equals(PointAttributes.COLOR_PACKED)) {
+                } else if (pointAttribute.name.Equals(PointAttributes.COLOR_PACKED)) {
                     for (int i = 0; i < numPoints; i++) {
                         byte r = data[offset + i * pointByteSize + 0];
                         byte g = data[offset + i * pointByteSize + 1];
@@ -154,6 +172,15 @@ namespace BAPointCloudRenderer.Loading {
                         colors[i] = new Color32(r, g, b, 255);
                     }
                     offset += 3;
+                }else if (pointAttribute.name.Equals(PointAttributes.RGBA)) {
+                    for (int i = 0; i < numPoints; i++) {
+                        byte r = data[offset + i * pointByteSize + 0];
+                        byte g = data[offset + i * pointByteSize + 1];
+                        byte b = data[offset + i * pointByteSize + 2];
+                        byte a = data[offset + i * pointByteSize + 3];
+                        colors[i] = new Color32(r, g, b, a);
+                    }
+                    offset += 4;
                 }
             }
             node.SetPoints(vertices, colors);
@@ -171,7 +198,14 @@ namespace BAPointCloudRenderer.Loading {
                 path += id.Substring(i * metaData.hierarchyStepSize, metaData.hierarchyStepSize) + "/";
             }
             path += "r" + id + fileending;
-            return File.ReadAllBytes(dataRPath + path);
+            if (File.Exists(metaData.cloudPath + dataRPath + path)){
+                return File.ReadAllBytes(metaData.cloudPath + dataRPath + path);
+            }else if(metaData.cloudUrl != null){
+              WebClient webClient = new WebClient();
+              webClient.DownloadFile(metaData.cloudUrl + dataRPath + path, metaData.cloudPath + dataRPath + path);
+              return File.ReadAllBytes(metaData.cloudPath + dataRPath + path);
+            }
+            return null;
         }
 
         /* Loads the points for that node and all its children
@@ -188,7 +222,7 @@ namespace BAPointCloudRenderer.Loading {
         }
 
         public static uint LoadAllPointsForNode(Node node) {
-            string dataRPath = node.MetaData.cloudPath + node.MetaData.octreeDir + "/r/";
+            string dataRPath = node.MetaData.octreeDir + "/r/"; // node.MetaData.cloudPath + ...
             return LoadAllPoints(dataRPath, node.MetaData, node);
         }
     }

--- a/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/Loading/PointAttributes.cs
+++ b/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/Loading/PointAttributes.cs
@@ -8,6 +8,7 @@ namespace BAPointCloudRenderer.Loading
     {
         public const string POSITION_CARTESIAN = "POSITION_CARTESIAN";
         public const string COLOR_PACKED = "COLOR_PACKED";
+        public const string RGBA = "RGBA";
 
     }
 }

--- a/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/Loading/PointAttributes.cs
+++ b/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/Loading/PointAttributes.cs
@@ -12,3 +12,4 @@ namespace BAPointCloudRenderer.Loading
 
     }
 }
+


### PR DESCRIPTION
Please find few modification to add two improvements: 

- add compatibility with Potree 1.7 format, especially on the management of the different point's storage formats, and colors types (RGBA).
- add the ability to read online cloud (from an url), for now the online cloud is save locally just before to be loaded into the 3d view.