### PR TITLE
Add compute buffer mesh configuration (for mobile performance rendering)

### DIFF
--- a/PointCloudRenderer/Assets/Resources/Shaders/PointCloud.shader
+++ b/PointCloudRenderer/Assets/Resources/Shaders/PointCloud.shader
@@ -1,0 +1,62 @@
+    Shader "Custom/Point Cloud"
+    {
+        Properties
+        {
+            _PointSize("Point Size", Float) = 0.05
+        }
+        SubShader
+        {
+            Pass
+            {
+                CGPROGRAM        
+                #pragma multi_compile_fog
+                #pragma vertex VSMain
+                #pragma fragment PSMain
+                #pragma target 5.0
+     
+                StructuredBuffer<uint> _ColorsBuffer;
+                StructuredBuffer<float3> _PointsBuffer;
+                float _PointSize;
+                float4x4 _Transform;
+                
+                #include "UnityCG.cginc"
+               
+                struct shaderdata
+                {
+                    float4 vertex : SV_POSITION;
+                    half3 color : COLOR;
+                    float psize : PSIZE;
+                    UNITY_FOG_COORDS(0)
+                };
+                
+                half3 PcxDecodeColor(uint data)
+                {
+                    half r = (data      ) & 0xff;
+                    half g = (data >>  8) & 0xff;
+                    half b = (data >> 16) & 0xff;
+                    half a = (data >> 24) & 0xff;
+                    return half3(r, g, b) * a * 16 / (255 * 255);
+                }
+     
+                shaderdata VSMain(uint id : SV_VertexID)
+                {
+                    shaderdata vs;
+                    float3 pt = _PointsBuffer[id];
+                    vs.vertex = UnityObjectToClipPos(pt);
+                    vs.color = PcxDecodeColor(_ColorsBuffer[id]);
+                    vs.psize = _PointSize;
+                    UNITY_TRANSFER_FOG(vs, vs.vertex);
+                    return vs;
+                }
+     
+                float4 PSMain(shaderdata ps) : SV_TARGET
+                {
+                    float4 c = float4(ps.color, 255);
+                    UNITY_APPLY_FOG(ps.fogCoord, c);
+                    return c;
+                }
+               
+                ENDCG
+            }
+        }
+    }

--- a/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/CloudController/ComputeBufferPointMesh.cs
+++ b/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/CloudController/ComputeBufferPointMesh.cs
@@ -1,0 +1,78 @@
+using Unity.Collections;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace BAPointCloudRenderer.CloudController {
+    public class ComputeBufferPointMesh : MonoBehaviour {
+        private ComputeBuffer _pointsbuffer;
+        private ComputeBuffer _colorsbuffer;
+        private Material _material;
+        private int _nbPoints = 0;
+        
+        private void OnDestroy () {
+            _pointsbuffer.Dispose ();
+            _colorsbuffer.Dispose ();
+        }
+
+        public void Init (Shader shader, Vector3[] vertexData, Color[] colorData) {
+            if (_pointsbuffer == null && _colorsbuffer == null) {
+                int count = 110000;
+                _pointsbuffer = new ComputeBuffer (count, sizeof (float) * 3, ComputeBufferType.Default, ComputeBufferMode.SubUpdates);
+                _colorsbuffer = new ComputeBuffer (count, sizeof (uint), ComputeBufferType.Default, ComputeBufferMode.SubUpdates);
+            }
+
+            if (_material == null) {
+                _material = new Material (shader);
+                _material.SetFloat ("_PointSize", 10);
+                _material.SetBuffer ("_PointsBuffer", _pointsbuffer);
+                _material.SetBuffer ("_ColorsBuffer", _colorsbuffer);
+                _material.enableInstancing = true;
+            }
+
+            _nbPoints = vertexData.Length;
+            int nbColors = colorData.Length;
+
+            var vertices = new NativeArray<float3> (_nbPoints, Allocator.Temp);
+            var colors = new NativeArray<uint> (nbColors, Allocator.Temp);
+            for (var i = 0; i < _nbPoints; i++) {
+                Vector3 pos = vertexData[i] + gameObject.transform.position;
+                vertices[i] = new float3 (pos.x, pos.y, pos.z);
+                colors[i] = EncodeColor (colorData[i]);
+            }
+
+            NativeArray<float3> tmpPoints = _pointsbuffer.BeginWrite<float3> (0, _nbPoints);
+            tmpPoints.CopyFrom (vertices);
+            _pointsbuffer.EndWrite<float3> (_nbPoints);
+
+            NativeArray<uint> tmpColors = _colorsbuffer.BeginWrite<uint> (0, nbColors);
+            tmpColors.CopyFrom (colors);
+            _colorsbuffer.EndWrite<uint> (nbColors);
+
+            vertices.Dispose ();
+            colors.Dispose ();
+        }
+
+        void OnRenderObject () {
+            if (_pointsbuffer == null || _colorsbuffer == null) {
+                return;
+            }
+            _material.SetPass (0);
+            Graphics.DrawProceduralNow (MeshTopology.Points, _nbPoints);
+        }
+
+        static uint EncodeColor (Color c) {
+            const float kMaxBrightness = 16;
+
+            var y = Mathf.Max (Mathf.Max (c.r, c.g), c.b);
+            y = Mathf.Clamp (Mathf.Ceil (y * 255 / kMaxBrightness), 1, 255);
+
+            var rgb = new Vector3 (c.r, c.g, c.b);
+            rgb *= 255 * 255 / (y * kMaxBrightness);
+
+            return ((uint) rgb.x) |
+                   ((uint) rgb.y << 8) |
+                   ((uint) rgb.z << 16) |
+                   ((uint) y << 24);
+        }
+    }
+}

--- a/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/ObjectCreation/ComputeBufferPointMeshConfiguration.cs
+++ b/PointCloudRenderer/Assets/Scripts/BAPointCloudRenderer/ObjectCreation/ComputeBufferPointMeshConfiguration.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using BAPointCloudRenderer.CloudController;
+using BAPointCloudRenderer.CloudData;
+using UnityEngine;
+
+namespace BAPointCloudRenderer.ObjectCreation {
+    public class ComputeBufferPointMeshConfiguration : MeshConfiguration {
+        public Shader shader;
+        private HashSet<GameObject> _gameObjectCollection = null;
+
+        public void Start () {
+            _gameObjectCollection = new HashSet<GameObject> ();
+        }
+
+        public override GameObject CreateGameObject (string name, Vector3[] vertexData, Color[] colorData, BoundingBox boundingBox, Transform parent, string version, Vector3d translationV2) {
+            GameObject gameObject = new GameObject (name);
+
+            //Set Translation
+            if (version == "2.0") {
+                // 20230125: potree v2 vertices have absolute coordinates,
+                // hence all gameobjects need to reside at Vector.Zero.
+                // And: the position must be set after parenthood has been granted.
+                //gameObject.transform.Translate(boundingBox.Min().ToFloatVector());
+                gameObject.transform.SetParent (parent, false);
+                gameObject.transform.localPosition = translationV2.ToFloatVector ();
+            } else {
+                gameObject.transform.Translate (boundingBox.Min ().ToFloatVector ());
+                gameObject.transform.SetParent (parent, false);
+            }
+            
+            ComputeBufferPointMesh computeBufferPointMesh = gameObject.AddComponent<ComputeBufferPointMesh> ();
+            computeBufferPointMesh.Init (shader, vertexData, colorData);
+
+            gameObject.AddComponent<BoundingBoxComponent> ().boundingBox = boundingBox;
+
+            if (_gameObjectCollection != null) {
+                _gameObjectCollection.Add (gameObject);
+            }
+
+            return gameObject;
+        }
+
+        public override void RemoveGameObject (GameObject gameObject) {
+            if (_gameObjectCollection != null) {
+                _gameObjectCollection.Remove (gameObject);
+            }
+            if (gameObject != null) {
+                Destroy (gameObject);
+            }
+        }
+
+        public override int GetMaximumPointsPerMesh () {
+            return 65000;
+        }
+    }
+}

--- a/PointCloudRenderer/Packages/manifest.json
+++ b/PointCloudRenderer/Packages/manifest.json
@@ -8,6 +8,7 @@
     "com.unity.ide.visualstudio": "2.0.17",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.multiplayer-hlapi": "1.0.6",
+    "com.unity.mathematics": "1.2.6",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.4.8",


### PR DESCRIPTION
We add some mesh configuration for mobile rendering.
We used compute buffer to render point clouds, this uses 4x fewer vertices than Quad4PointMeshConfiguration.

It solve a part of : https://github.com/SFraissTU/BA_PointCloud/issues/40